### PR TITLE
load/save - verbose

### DIFF
--- a/R/check_if_loaded.R
+++ b/R/check_if_loaded.R
@@ -1,19 +1,19 @@
 #' @title Confirm that the selected file is present in selected environment
 #' @param file_name Name of the selected file
 #' @param env The environment to test the presence of the file in
-#' @param silent Logical. Should there be no message?
+#' @param verbose Logical. Should there be output message?
 #' @export
 check_if_loaded <-
   function(file_name,
            env = rlang::current_env,
-           silent = FALSE) {
+           verbose = TRUE) {
     check_class("file_name", "character")
 
     check_class("env", "environment")
 
 
     if (
-      silent == FALSE
+      verbose == TRUE
     ) {
       stop_if_not(
         exists(

--- a/R/get_latest_file.R
+++ b/R/get_latest_file.R
@@ -1,13 +1,15 @@
 #' @title Detect the newest version of the selected file and load it
 #' @param file_name Name of the object to save in quotes
 #' @param dir Directory path
+#' @param verbose Logical. Should there be output message?
 #' @return Object of latest version of the `file_name`
 #' @description Look into the folder `dir` and find the version of the file with
 #'  the most recent date and load it
 #' @export
 get_latest_file <-
     function(file_name,
-             dir = here::here()) {
+             dir = here::here(),
+             verbose = TRUE) {
         current_frame <-
             sys.nframe()
         current_env <-
@@ -26,14 +28,20 @@ get_latest_file <-
         if (
             is.na(file_last_name)
         ) {
-            stop(
-                paste(
-                    "Did not detect file",
-                    paste_as_vector(file_name),
-                    "in",
-                    paste_as_vector(dir)
+            if (
+                verbose == TRUE
+            ) {
+                stop(
+                    paste(
+                        "Did not detect file",
+                        paste_as_vector(file_name),
+                        "in",
+                        paste_as_vector(dir)
+                    )
                 )
-            )
+            } else {
+                stop_quietly()
+            }
         }
 
         file_format <-
@@ -42,7 +50,13 @@ get_latest_file <-
         if (
             is.na(file_format)
         ) {
-            stop("Cannot extract file format")
+            if (
+                verbose == TRUE
+            ) {
+                stop("Cannot extract file format")
+            } else {
+                stop_quietly()
+            }
         }
 
         # assing NULL to prevent the R-CMD-check to fail
@@ -88,9 +102,13 @@ get_latest_file <-
             envir = current_env
         )
 
-        usethis::ui_done(
-            paste("Automatically loaded file", file_last_name)
-        )
+        if (
+            verbose == TRUE
+        ) {
+            usethis::ui_done(
+                paste("Automatically loaded file", file_last_name)
+            )
+        }
 
         return(data_object)
     }

--- a/R/get_latest_file_name.R
+++ b/R/get_latest_file_name.R
@@ -2,7 +2,7 @@
 #' @param file_name Name of the object to save in quotes
 #' @param dir Directory path
 #' @param folder Logical. Is the selected file a folder?
-#' @param silent Logical. Should error message be ouput
+#' @param verbose Logical. Should there be output error message?
 #' @return Object name of the most recent file
 #' @description look into the `dir` folder and find the version of the file
 #' with the most recent name
@@ -11,14 +11,14 @@ get_latest_file_name <-
     function(file_name,
              dir = here::here(),
              folder = FALSE,
-             silent = FALSE) {
+             verbose = TRUE) {
         check_class("file_name", c("character", "logical"))
 
         check_class("dir", "character")
 
         check_class("folder", "logical")
 
-        check_class("silent", "logical")
+        check_class("verbose", "logical")
 
         # helper functions
         check_vector_length <-
@@ -27,7 +27,7 @@ get_latest_file_name <-
                     length(sel_vec) == 0
                 ) {
                     if (
-                        silent == FALSE
+                        verbose == TRUE
                     ) {
                         usethis::ui_oops("Selected file not present")
                     }

--- a/R/save_latest_file.R
+++ b/R/save_latest_file.R
@@ -14,6 +14,7 @@
 #' @param use_sha Logical. If True, the file will be given SHA code in the
 #' file name. when comapring files, if file has SHA code, the comparison can
 #' be done via SHA (without loading the file -> less memory).
+#' @param verbose Logical. Should there be output message?
 #' @return NULL
 #' @description Look into the folder and find the version of the file with
 #'  the most recent name. Compare the last saved file and selected file and
@@ -40,7 +41,8 @@ save_latest_file <-
                  "uncompressed",
                  "archive"
              ),
-             use_sha = FALSE) {
+             use_sha = FALSE,
+             verbose = TRUE) {
         current_frame <-
             sys.nframe()
         parent_frame <-
@@ -125,7 +127,7 @@ save_latest_file <-
         check_if_loaded(
             file_name = "object_to_save",
             env = current_env,
-            silent = TRUE
+            verbose = FALSE
         )
 
         if (
@@ -180,32 +182,42 @@ save_latest_file <-
             get_latest_file_name(
                 file_name = file_name,
                 dir = dir,
-                silent = TRUE
+                verbose = FALSE
             )
 
         # if there is not a previous version of the file
         if (
             is.na(latest_file_name)
         ) {
-            usethis::ui_done(
-                paste(
-                    "Have not find previous version of the file.",
-                    "Saving the file with",
-                    prefered_format, "format."
+            if (
+                verbose == TRUE
+            ) {
+                usethis::ui_done(
+                    paste(
+                        "Have not find previous version of the file.",
+                        "Saving the file with",
+                        prefered_format, "format."
+                    )
                 )
-            )
+            }
 
             eval(parse(text = save_command), envir = current_env)
 
             # stop the funtcion
-            return("Done")
+            if (
+                isTRUE(verbose)
+            ) {
+                return("Done")
+            } else {
+                return(NULL)
+            }
         }
 
         lastest_file_format <-
             get_format_from_name(latest_file_name)
 
         if (
-            prefered_format != lastest_file_format
+            prefered_format != lastest_file_format && isTRUE(verbose)
         ) {
             usethis::ui_info(
                 paste0(
@@ -296,9 +308,13 @@ save_latest_file <-
         if (
             is_the_lastest_same == FALSE
         ) {
-            usethis::ui_done(
-                "Found older file, overwriting it with new changes."
-            )
+            if (
+                isTRUE(verbose)
+            ) {
+                usethis::ui_done(
+                    "Found older file, overwriting it with new changes."
+                )
+            }
 
             latest_file_date <-
                 get_date_from_name(latest_file_name)
@@ -316,12 +332,31 @@ save_latest_file <-
 
             eval(parse(text = save_command), envir = current_env)
 
-            return("Done")
+            if (
+                isTRUE(verbose)
+            ) {
+                return("Done")
+            } else {
+                return(NULL)
+            }
         }
 
-        usethis::ui_info(
-            "Found older file but did not detect any changes. Not overwritting."
-        )
+        if (
+            isTRUE(verbose)
+        ) {
+            usethis::ui_info(
+                paste(
+                    "Found older file but did not detect any changes.",
+                    "Not overwritting."
+                )
+            )
+        }
 
-        return("Done")
+        if (
+            isTRUE(verbose)
+        ) {
+            return("Done")
+        } else {
+            return(NULL)
+        }
     }

--- a/man/check_if_loaded.Rd
+++ b/man/check_if_loaded.Rd
@@ -4,14 +4,14 @@
 \alias{check_if_loaded}
 \title{Confirm that the selected file is present in selected environment}
 \usage{
-check_if_loaded(file_name, env = rlang::current_env, silent = FALSE)
+check_if_loaded(file_name, env = rlang::current_env, verbose = TRUE)
 }
 \arguments{
 \item{file_name}{Name of the selected file}
 
 \item{env}{The environment to test the presence of the file in}
 
-\item{silent}{Logical. Should there be no message?}
+\item{verbose}{Logical. Should there be output message?}
 }
 \description{
 Confirm that the selected file is present in selected environment

--- a/man/get_latest_file.Rd
+++ b/man/get_latest_file.Rd
@@ -4,12 +4,14 @@
 \alias{get_latest_file}
 \title{Detect the newest version of the selected file and load it}
 \usage{
-get_latest_file(file_name, dir = here::here())
+get_latest_file(file_name, dir = here::here(), verbose = TRUE)
 }
 \arguments{
 \item{file_name}{Name of the object to save in quotes}
 
 \item{dir}{Directory path}
+
+\item{verbose}{Logical. Should there be output message?}
 }
 \value{
 Object of latest version of the \code{file_name}

--- a/man/get_latest_file_name.Rd
+++ b/man/get_latest_file_name.Rd
@@ -8,7 +8,7 @@ get_latest_file_name(
   file_name,
   dir = here::here(),
   folder = FALSE,
-  silent = FALSE
+  verbose = TRUE
 )
 }
 \arguments{
@@ -18,7 +18,7 @@ get_latest_file_name(
 
 \item{folder}{Logical. Is the selected file a folder?}
 
-\item{silent}{Logical. Should error message be ouput}
+\item{verbose}{Logical. Should there be output error message?}
 }
 \value{
 Object name of the most recent file

--- a/man/save_latest_file.Rd
+++ b/man/save_latest_file.Rd
@@ -11,7 +11,8 @@ save_latest_file(
   current_date = Sys.Date(),
   prefered_format = c("rds", "qs", "csv"),
   preset = c("high", "balanced", "fast", "uncompressed", "archive"),
-  use_sha = FALSE
+  use_sha = FALSE,
+  verbose = TRUE
 )
 }
 \arguments{
@@ -34,6 +35,8 @@ One of "fast", "balanced", "high" (default), "archive",
 \item{use_sha}{Logical. If True, the file will be given SHA code in the
 file name. when comapring files, if file has SHA code, the comparison can
 be done via SHA (without loading the file -> less memory).}
+
+\item{verbose}{Logical. Should there be output message?}
 }
 \description{
 Look into the folder and find the version of the file with


### PR DESCRIPTION
- Unify the agrument name in `verbose`
- add `verbose` option to all save/load fncs